### PR TITLE
Move to use patch over native zkVM SHA2 Impl Digest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,6 +1337,7 @@ dependencies = [
  "chacha20",
  "common",
  "risc0-zkvm",
+ "sha2",
 ]
 
 [[package]]
@@ -3227,8 +3228,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388fdede7cef649bce0d63876d1a9e3f515"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3228,7 +3228,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.8-sp1-4.0.0#1f224388fdede7cef649bce0d63876d1a9e3f515"
+source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.10.8-risczero.0#244dc3b08788f7a4ccce14c66896ae3b4f24c166"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ methods = { path = "methods" }
 host = { path = "host" }
 common = { path = "common" }
 
+sha2 = "=0.10.8"
 chacha20 = "0.9.1"
 hex-literal = "1.0.0"
 
@@ -19,6 +20,9 @@ risc0-zkvm = { version = "2.0",  default-features = false, features = ['std'] }
 risc0-build = "2.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = "1.0"
+
+[patch.crates-io]
+sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-4.0.0" }
 
 # Always optimize; building and running the guest takes much longer without optimization.
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = "1.0"
 
 [patch.crates-io]
-sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-4.0.0" }
+sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
 
 # Always optimize; building and running the guest takes much longer without optimization.
 [profile.dev]

--- a/methods/guest/Cargo.toml
+++ b/methods/guest/Cargo.toml
@@ -6,5 +6,6 @@ edition.workspace = true
 [dependencies]
 common.workspace = true
 
+sha2.workspace = true
 risc0-zkvm = { workspace = true,  default-features = false, features = ['std'] }
 chacha20.workspace = true

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -1,9 +1,8 @@
 use chacha20::cipher::{KeyIvInit, StreamCipher};
 use chacha20::ChaCha20;
-use risc0_zkvm::{
-    guest::env,
-    sha::{Impl, Sha256},
-};
+use risc0_zkvm::guest::env;
+
+use sha2::{Digest, Sha256};
 
 use common::INPUT_BYTES_LENGTH;
 
@@ -19,8 +18,8 @@ fn main() {
     env::read_slice(&mut buffer);
 
     // Hash plaintext & commit
-    let digest = Impl::hash_bytes(&buffer);
-    env::commit(&digest);
+    let digest = Sha256::digest(&buffer);
+    env::commit_slice(&digest);
 
     // TODO:
     // - Hash key and/or nonce & commit?


### PR DESCRIPTION
Testing this branch vs what I would expect to be nearly identical in cycles to [an sp1 impl](https://github.com/nuke-web3/sp1-chacha/tree/9738aa48c0c446e9911c8411cce5827f0a57aa99)

Note that for the input data (in `static` dir), both correctly hash (SHA2) to: 
```
0x7a354f1d1a66ccd0de0b58ad76526773d5eb3d7e0085bf906ccac8daae586413
```

But the present mock encryption using risc0's included SHA2 impl that AFAIK wraps the `Sha256::digest()` is ~2x more performant :face_with_open_eyes_and_hand_over_mouth:

```sh
# Cycle counts of execution only:
157_700_235 = sp1 # using patch
73_629_685 = risc0 # using included SHA2 Digest (existing)
161_380_587 = risc0 # using path (this PR)
```

I would like to know why and how it can be applied to sp1 so the cycles are in the ~75k range rather than ~160k that the patch provides.
